### PR TITLE
feat: Add OS auto-detection and directory management to watcher

### DIFF
--- a/client/lua/config_auto.lua
+++ b/client/lua/config_auto.lua
@@ -1,0 +1,82 @@
+-- Automatic configuration with OS detection
+-- This config automatically detects the operating system and sets appropriate paths
+
+local function get_temp_directory()
+    -- Try environment variables first
+    local temp = os.getenv("TEMP") or os.getenv("TMP") or os.getenv("TMPDIR")
+    
+    if temp then
+        -- Windows typically uses backslashes, but Lua handles forward slashes fine
+        temp = string.gsub(temp, "\\", "/")
+        if not string.match(temp, "/$") then
+            temp = temp .. "/"
+        end
+        return temp .. "soullink_events/"
+    end
+    
+    -- Fallback paths based on OS detection
+    local separator = package.config:sub(1,1)
+    if separator == "\\" then
+        -- Windows
+        local username = os.getenv("USERNAME") or "User"
+        return "C:/Users/" .. username .. "/AppData/Local/Temp/soullink_events/"
+    else
+        -- Unix/Linux/macOS
+        return "/tmp/soullink_events/"
+    end
+end
+
+local function get_desktop_directory()
+    -- Alternative: use Desktop for easier debugging
+    local separator = package.config:sub(1,1)
+    if separator == "\\" then
+        -- Windows
+        local userprofile = os.getenv("USERPROFILE")
+        if userprofile then
+            return string.gsub(userprofile, "\\", "/") .. "/Desktop/soullink_events/"
+        end
+    else
+        -- Unix/Linux/macOS
+        local home = os.getenv("HOME")
+        if home then
+            return home .. "/Desktop/soullink_events/"
+        end
+    end
+    return get_temp_directory()  -- Fallback to temp
+end
+
+-- Auto-detected configuration
+local config = {
+    -- API settings (adjust these for your setup)
+    api_base_url = "http://127.0.0.1:8000",
+    
+    -- IMPORTANT: Replace these with your actual UUIDs from the admin panel
+    run_id = "f92209cf-b5a8-490c-a6d6-49488be06aaf",
+    player_id = "7287b21a-40a9-40ce-ad76-54154ac6ecf1",
+    
+    -- Auto-detected output directory
+    -- Change to get_desktop_directory() if you prefer Desktop for easier access
+    output_dir = get_temp_directory(),
+    
+    -- Optional: Override with a custom path
+    -- output_dir = "C:/soullink_events/",  -- Windows example
+    -- output_dir = "/home/user/soullink_events/",  -- Linux example
+    
+    -- Polling and debug settings
+    poll_interval = 60,  -- Check every 60 frames (1 second)
+    debug = true,
+    max_runtime = 3600,  -- Stop after 1 hour (0 = unlimited)
+    
+    -- Memory profile for your ROM version
+    memory_profile = "US"  -- Options: "US" or "EU"
+}
+
+-- Print detected configuration for debugging
+print("=== Auto-Configuration ===")
+print("OS Detection: " .. (package.config:sub(1,1) == "\\" and "Windows" or "Unix-like"))
+print("Output Directory: " .. config.output_dir)
+print("Run ID: " .. config.run_id)
+print("Player ID: " .. config.player_id)
+print("========================")
+
+return config

--- a/client/lua/create_output_dir.lua
+++ b/client/lua/create_output_dir.lua
@@ -1,0 +1,63 @@
+-- Helper script to create the output directory if it doesn't exist
+-- Run this once before using the tracker
+
+local function get_temp_directory()
+    local temp = os.getenv("TEMP") or os.getenv("TMP") or os.getenv("TMPDIR")
+    
+    if temp then
+        temp = string.gsub(temp, "\\", "/")
+        if not string.match(temp, "/$") then
+            temp = temp .. "/"
+        end
+        return temp .. "soullink_events/"
+    end
+    
+    local separator = package.config:sub(1,1)
+    if separator == "\\" then
+        local username = os.getenv("USERNAME") or "User"
+        return "C:/Users/" .. username .. "/AppData/Local/Temp/soullink_events/"
+    else
+        return "/tmp/soullink_events/"
+    end
+end
+
+local output_dir = get_temp_directory()
+
+print("=== SoulLink Directory Setup ===")
+print("Detected OS: " .. (package.config:sub(1,1) == "\\" and "Windows" or "Unix-like"))
+print("Output directory: " .. output_dir)
+
+-- Try to create directory
+local test_file = output_dir .. "test_" .. os.time() .. ".txt"
+local file = io.open(test_file, "w")
+
+if file then
+    file:write("Directory test successful at " .. os.date("%Y-%m-%d %H:%M:%S"))
+    file:close()
+    print("✓ Directory exists and is writable")
+    print("✓ Test file created: " .. test_file)
+    
+    -- Clean up test file
+    os.remove(test_file)
+else
+    print("✗ Directory does not exist or is not writable")
+    print("")
+    print("Please create this directory manually:")
+    print("  " .. output_dir)
+    print("")
+    
+    if package.config:sub(1,1) == "\\" then
+        -- Windows instructions
+        print("Windows PowerShell command:")
+        print('  New-Item -ItemType Directory -Force -Path "' .. string.gsub(output_dir, "/", "\\") .. '"')
+        print("")
+        print("Or Windows CMD command:")
+        print('  mkdir "' .. string.gsub(output_dir, "/", "\\") .. '"')
+    else
+        -- Unix instructions
+        print("Terminal command:")
+        print('  mkdir -p "' .. output_dir .. '"')
+    end
+end
+
+print("================================")

--- a/client/lua/pokemon_tracker_auto.lua
+++ b/client/lua/pokemon_tracker_auto.lua
@@ -1,0 +1,241 @@
+--[[
+Pokemon SoulLink Tracker - Auto-Configuration Version
+Automatically detects OS and sets appropriate paths
+]]
+
+-- Auto-detect temp directory
+local function get_output_directory()
+    local temp = os.getenv("TEMP") or os.getenv("TMP") or os.getenv("TMPDIR")
+    
+    if temp then
+        temp = string.gsub(temp, "\\", "/")
+        if not string.match(temp, "/$") then
+            temp = temp .. "/"
+        end
+        return temp .. "soullink_events/"
+    end
+    
+    -- Fallback based on OS
+    local separator = package.config:sub(1,1)
+    if separator == "\\" then
+        local username = os.getenv("USERNAME") or "User"
+        return "C:/Users/" .. username .. "/AppData/Local/Temp/soullink_events/"
+    else
+        return "/tmp/soullink_events/"
+    end
+end
+
+-- Load configuration with auto-detection
+local function load_config()
+    -- First try to load manual config
+    local config_files = {"config.lua", "./config.lua", "client/lua/config.lua"}
+    
+    for _, path in ipairs(config_files) do
+        local success, config = pcall(dofile, path)
+        if success and type(config) == "table" then
+            print("[Config] Loaded from: " .. path)
+            
+            -- Override output_dir with auto-detected path if not set
+            if not config.output_dir or config.output_dir == "/tmp/soullink_events/" then
+                config.output_dir = get_output_directory()
+                print("[Config] Auto-detected output dir: " .. config.output_dir)
+            end
+            
+            return config
+        end
+    end
+    
+    -- No config found, use defaults with auto-detection
+    print("[Config] No config.lua found, using auto-configuration")
+    return {
+        api_base_url = "http://127.0.0.1:8000",
+        run_id = "MISSING_RUN_ID",
+        player_id = "MISSING_PLAYER_ID",
+        output_dir = get_output_directory(),
+        poll_interval = 60,
+        debug = true,
+        max_runtime = 3600
+    }
+end
+
+local CONFIG = load_config()
+
+print("=== Pokemon SoulLink Tracker (Auto-Config) ===")
+print("Output Directory: " .. CONFIG.output_dir)
+print("Run ID: " .. CONFIG.run_id)
+print("Player ID: " .. CONFIG.player_id)
+print("===============================================")
+
+-- Test directory access
+local function test_directory()
+    local test_file = CONFIG.output_dir .. "startup_test_" .. os.time() .. ".json"
+    local file = io.open(test_file, "w")
+    
+    if file then
+        file:write('{"type":"test","message":"Directory writable"}')
+        file:close()
+        print("[OK] Output directory is writable: " .. CONFIG.output_dir)
+        return true
+    else
+        print("[ERROR] Cannot write to: " .. CONFIG.output_dir)
+        print("[ERROR] Please create this directory or check permissions")
+        return false
+    end
+end
+
+if not test_directory() then
+    print("Script will continue but events won't be saved!")
+end
+
+-- Memory addresses for Pokemon HGSS
+local MEMORY = {
+    party_pokemon = 0x02234804,
+    party_count = 0x02234884,
+    wild_pokemon = 0x0223AB00,
+    battle_state = 0x02226E18,
+    current_route = 0x02256AA4,
+    current_map = 0x02256AA6,
+    menu_state = 0x021C4D94,
+    player_state = 0x021BF6A0,
+    rod_type = 0x021D4F0C
+}
+
+-- Pokemon data offsets
+local POKEMON_OFFSETS = {
+    species = 0x00,
+    personality = 0x08,
+    level = 0x54,
+    hp_current = 0x56,
+    hp_max = 0x58,
+    trainer_id = 0x04
+}
+
+-- Game state
+local game_state = {
+    in_encounter = false,
+    last_wild_species = 0,
+    last_wild_level = 0,
+    last_route = 0,
+    frame_count = 0,
+    last_battle_state = 0
+}
+
+-- Safe memory reading
+local function safe_read_u8(addr)
+    if addr and addr > 0 then
+        return memory.readbyte(addr)
+    end
+    return 0
+end
+
+local function safe_read_u16(addr)
+    if addr and addr > 0 then
+        return memory.readword(addr)
+    end
+    return 0
+end
+
+local function safe_read_u32(addr)
+    if addr and addr > 0 then
+        return memory.readdword(addr)
+    end
+    return 0
+end
+
+-- Get current timestamp
+local function get_current_time()
+    return os.date("!%Y-%m-%dT%H:%M:%SZ")
+end
+
+-- Write event to file
+local function write_event(event_data)
+    local timestamp = os.time()
+    local random = math.random(1000, 9999)
+    local filename = CONFIG.output_dir .. "event_" .. timestamp .. "_" .. random .. ".json"
+    
+    local file = io.open(filename, "w")
+    if file then
+        file:write(event_data)
+        file:close()
+        print("[Event] Written: " .. filename)
+        return true
+    else
+        print("[Error] Cannot write: " .. filename)
+        return false
+    end
+end
+
+-- Create encounter event
+local function create_encounter_event(species, level, route)
+    if CONFIG.run_id == "MISSING_RUN_ID" then
+        print("[Warning] Missing run_id/player_id - get from admin panel!")
+    end
+    
+    local event = string.format([[{
+    "type": "encounter",
+    "run_id": "%s",
+    "player_id": "%s",
+    "time": "%s",
+    "route_id": %d,
+    "species_id": %d,
+    "level": %d,
+    "shiny": false,
+    "method": "grass",
+    "event_version": "auto"
+}]], CONFIG.run_id, CONFIG.player_id, get_current_time(), route, species, level)
+    
+    write_event(event)
+    print(string.format("[Encounter] Species %d Level %d on Route %d", species, level, route))
+end
+
+-- Detect encounters
+local function detect_encounter()
+    local battle_state = safe_read_u8(MEMORY.battle_state)
+    
+    -- Check for battle state change
+    if battle_state ~= game_state.last_battle_state then
+        game_state.last_battle_state = battle_state
+        
+        if battle_state > 0 then
+            -- Battle started, check for wild Pokemon
+            local wild_species = safe_read_u16(MEMORY.wild_pokemon + POKEMON_OFFSETS.species)
+            local wild_level = safe_read_u8(MEMORY.wild_pokemon + POKEMON_OFFSETS.level)
+            local current_route = safe_read_u16(MEMORY.current_route)
+            
+            if wild_species > 0 and wild_species < 1000 and not game_state.in_encounter then
+                game_state.in_encounter = true
+                game_state.last_wild_species = wild_species
+                game_state.last_wild_level = wild_level
+                
+                create_encounter_event(wild_species, wild_level, current_route)
+            end
+        else
+            -- Battle ended
+            if game_state.in_encounter then
+                game_state.in_encounter = false
+                print("[Battle] Ended")
+            end
+        end
+    end
+end
+
+-- Main monitoring function
+local function monitor_game()
+    game_state.frame_count = game_state.frame_count + 1
+    
+    -- Check every N frames
+    if game_state.frame_count >= CONFIG.poll_interval then
+        game_state.frame_count = 0
+        
+        -- Skip if in menu
+        local menu_state = safe_read_u8(MEMORY.menu_state)
+        if menu_state == 0 then
+            detect_encounter()
+        end
+    end
+end
+
+-- Register frame callback
+gui.register(monitor_game)
+
+print("Script running! Enter a wild Pokemon battle to test.")

--- a/client/lua/pokemon_tracker_debug.lua
+++ b/client/lua/pokemon_tracker_debug.lua
@@ -1,0 +1,183 @@
+-- Pokemon SoulLink Tracker - Debug Version
+-- This script logs detailed information to help diagnose encounter detection issues
+
+-- Try to load configuration
+local function load_config()
+    local config_paths = {
+        "config.lua",
+        "./config.lua",
+        "client/lua/config.lua",
+        "../config.lua",
+        "../../config.lua"
+    }
+    
+    for _, path in ipairs(config_paths) do
+        local success, result = pcall(dofile, path)
+        if success and type(result) == "table" then
+            print("[CONFIG] Loaded from: " .. path)
+            return result
+        end
+    end
+    
+    print("[CONFIG] Using fallback configuration")
+    return {
+        api_base_url = "http://127.0.0.1:8000",
+        run_id = "MISSING_RUN_ID",
+        player_id = "MISSING_PLAYER_ID",
+        output_dir = "C:/Users/Alex/AppData/Local/Temp/soullink_events/",
+        poll_interval = 30,  -- Check more frequently for debugging
+        debug = true
+    }
+end
+
+local CONFIG = load_config()
+print("[CONFIG] Output directory: " .. CONFIG.output_dir)
+
+-- Memory addresses for Pokemon HGSS
+local MEMORY = {
+    party_pokemon = 0x02234804,
+    party_count = 0x02234884,
+    wild_pokemon = 0x0223AB00,
+    battle_state = 0x02226E18,
+    current_route = 0x02256AA4,
+    current_map = 0x02256AA6,
+    menu_state = 0x021C4D94,
+    player_state = 0x021BF6A0,
+    rod_type = 0x021D4F0C
+}
+
+-- Alternative memory addresses to try (EU version)
+local MEMORY_ALT = {
+    battle_state = 0x02226E1C,  -- Sometimes off by 4 bytes
+    wild_pokemon = 0x0223AB04,
+}
+
+-- Pokemon data offsets
+local POKEMON_OFFSETS = {
+    species = 0x00,
+    level = 0x54
+}
+
+-- State tracking
+local state = {
+    frame_count = 0,
+    last_battle_state = 0,
+    last_wild_species = 0,
+    debug_log_count = 0,
+    in_encounter = false
+}
+
+-- Safe memory reading
+local function safe_read_u8(addr)
+    if addr and addr > 0 then
+        return memory.readbyte(addr)
+    end
+    return 0
+end
+
+local function safe_read_u16(addr)
+    if addr and addr > 0 then
+        return memory.readword(addr)
+    end
+    return 0
+end
+
+-- Write debug log to file
+local function write_debug_log(message)
+    local timestamp = os.time()
+    local filename = CONFIG.output_dir .. "debug_" .. timestamp .. "_" .. state.debug_log_count .. ".txt"
+    state.debug_log_count = state.debug_log_count + 1
+    
+    local file = io.open(filename, "w")
+    if file then
+        file:write("=== Pokemon Tracker Debug Log ===\n")
+        file:write("Time: " .. os.date("%Y-%m-%d %H:%M:%S") .. "\n")
+        file:write("Message: " .. message .. "\n")
+        file:close()
+        print("[DEBUG] Log written: " .. filename)
+    else
+        print("[ERROR] Cannot write to: " .. filename)
+        print("[ERROR] Check if directory exists: " .. CONFIG.output_dir)
+    end
+end
+
+-- Main debug monitoring
+local function debug_monitor()
+    -- Read memory values
+    local battle_state = safe_read_u8(MEMORY.battle_state)
+    local battle_state_alt = safe_read_u8(MEMORY_ALT.battle_state)
+    local wild_species = safe_read_u16(MEMORY.wild_pokemon + POKEMON_OFFSETS.species)
+    local wild_species_alt = safe_read_u16(MEMORY_ALT.wild_pokemon + POKEMON_OFFSETS.species)
+    local wild_level = safe_read_u8(MEMORY.wild_pokemon + POKEMON_OFFSETS.level)
+    local menu_state = safe_read_u8(MEMORY.menu_state)
+    local current_route = safe_read_u16(MEMORY.current_route)
+    local party_count = safe_read_u8(MEMORY.party_count)
+    
+    -- Log detailed state every 60 frames (1 second)
+    if state.frame_count % 60 == 0 then
+        local debug_info = string.format(
+            "Frame %d | Battle: %d (alt: %d) | Wild Species: %d (alt: %d) | Level: %d | Menu: %d | Route: %d | Party: %d",
+            state.frame_count, battle_state, battle_state_alt, wild_species, wild_species_alt, 
+            wild_level, menu_state, current_route, party_count
+        )
+        print(debug_info)
+        
+        -- Write to file every 5 seconds
+        if state.frame_count % 300 == 0 then
+            write_debug_log(debug_info)
+        end
+    end
+    
+    -- Detect battle state changes (primary address)
+    if battle_state ~= state.last_battle_state then
+        local message = string.format(
+            "BATTLE STATE CHANGE: %d -> %d | Wild: Species=%d Level=%d",
+            state.last_battle_state, battle_state, wild_species, wild_level
+        )
+        print("[IMPORTANT] " .. message)
+        write_debug_log(message)
+        state.last_battle_state = battle_state
+        
+        -- Check if this is a new encounter
+        if battle_state > 0 and wild_species > 0 and wild_species < 1000 then
+            print("[ENCOUNTER DETECTED] Species: " .. wild_species .. " Level: " .. wild_level)
+            write_debug_log("ENCOUNTER DETECTED - Species: " .. wild_species .. " Level: " .. wild_level)
+            state.in_encounter = true
+        elseif battle_state == 0 and state.in_encounter then
+            print("[ENCOUNTER ENDED]")
+            write_debug_log("ENCOUNTER ENDED")
+            state.in_encounter = false
+        end
+    end
+    
+    -- Check alternative battle state
+    if battle_state_alt > 0 and battle_state_alt ~= battle_state then
+        print("[ALT BATTLE] Alternative battle state active: " .. battle_state_alt)
+    end
+    
+    -- Detect wild species changes
+    if wild_species ~= state.last_wild_species and wild_species > 0 then
+        local message = string.format("WILD SPECIES CHANGE: %d -> %d", state.last_wild_species, wild_species)
+        print("[SPECIES] " .. message)
+        write_debug_log(message)
+        state.last_wild_species = wild_species
+    end
+end
+
+-- Frame callback
+local function on_frame()
+    state.frame_count = state.frame_count + 1
+    
+    -- Run monitoring every frame for debugging
+    debug_monitor()
+end
+
+-- Initialize
+print("=== Pokemon Tracker Debug Mode ===")
+print("This will log detailed memory information to help diagnose issues")
+print("Output directory: " .. CONFIG.output_dir)
+print("Check the debug files for memory state information")
+write_debug_log("Debug script initialized")
+
+-- Register callback
+gui.register(on_frame)

--- a/client/lua/simple_battle_detector.lua
+++ b/client/lua/simple_battle_detector.lua
@@ -1,0 +1,102 @@
+-- Simple Battle Detection Test for Pokemon HGSS
+-- This script tests if we can detect when you're in battle
+
+print("=== Simple Battle Detector ===")
+print("This will show when you enter/exit battles")
+print("If this doesn't work, the memory addresses are wrong")
+print("================================")
+
+-- Try multiple battle state addresses
+local ADDRESSES = {
+    -- Primary US addresses
+    {name = "US Primary", addr = 0x02226E18},
+    {name = "US Alt", addr = 0x02226E1C},
+    
+    -- EU addresses
+    {name = "EU Primary", addr = 0x02226E20},
+    {name = "EU Alt", addr = 0x02226E24},
+    
+    -- Other common addresses
+    {name = "Battle Flag 1", addr = 0x02228870},
+    {name = "Battle Flag 2", addr = 0x021BF6B0},
+    {name = "Battle Mode", addr = 0x02226E10},
+}
+
+-- Track last values
+local last_values = {}
+for i, addr_info in ipairs(ADDRESSES) do
+    last_values[i] = 0
+end
+
+-- Check for battle every frame
+local frame_count = 0
+
+local function check_battle()
+    frame_count = frame_count + 1
+    
+    -- Only check every 30 frames (0.5 seconds)
+    if frame_count < 30 then
+        return
+    end
+    frame_count = 0
+    
+    local changes_detected = false
+    
+    for i, addr_info in ipairs(ADDRESSES) do
+        local current_value = memory.readbyte(addr_info.addr)
+        
+        -- Check if value changed
+        if current_value ~= last_values[i] then
+            print(string.format("[%s] Changed: %d -> %d %s",
+                os.date("%H:%M:%S"),
+                last_values[i],
+                current_value,
+                addr_info.name))
+            
+            -- Specifically note battle start/end
+            if last_values[i] == 0 and current_value > 0 then
+                print("  ^^^ BATTLE STARTED at " .. addr_info.name .. " ^^^")
+                changes_detected = true
+            elseif last_values[i] > 0 and current_value == 0 then
+                print("  vvv BATTLE ENDED at " .. addr_info.name .. " vvv")
+                changes_detected = true
+            end
+            
+            last_values[i] = current_value
+        end
+    end
+    
+    -- If we detected changes, also check for wild Pokemon
+    if changes_detected then
+        local wild_species = memory.readword(0x0223AB00)  -- Species ID at wild Pokemon address
+        local wild_level = memory.readbyte(0x0223AB00 + 0x54)  -- Level offset
+        
+        if wild_species > 0 and wild_species < 1000 then
+            print(string.format("  Wild Pokemon detected: Species=%d, Level=%d", wild_species, wild_level))
+        end
+    end
+end
+
+-- Also create a test file to verify file writing works
+local function test_file_write()
+    local test_dir = "/tmp/soullink_events/"
+    local test_file = test_dir .. "battle_test_" .. os.time() .. ".txt"
+    
+    local file = io.open(test_file, "w")
+    if file then
+        file:write("Battle detection test at " .. os.date("%Y-%m-%d %H:%M:%S"))
+        file:close()
+        print("Test file written successfully: " .. test_file)
+    else
+        print("ERROR: Cannot write to " .. test_dir)
+        print("Please check directory permissions or create the directory")
+    end
+end
+
+-- Test file writing on startup
+test_file_write()
+
+-- Register frame callback
+gui.register(check_battle)
+
+print("Script running. Enter a wild Pokemon battle to test detection.")

--- a/client/lua/test_memory_addresses.lua
+++ b/client/lua/test_memory_addresses.lua
@@ -1,0 +1,103 @@
+-- Test script to find correct memory addresses for encounter detection
+-- Run this while in a battle to see which addresses have non-zero values
+
+print("=== Memory Address Scanner for Pokemon HGSS ===")
+print("Instructions:")
+print("1. Start a wild Pokemon encounter")
+print("2. Run this script while in battle")
+print("3. Check which addresses show non-zero values")
+print("===============================================")
+
+-- Common battle state addresses to test
+local addresses_to_test = {
+    -- US version addresses
+    {name = "US Battle State 1", addr = 0x02226E18},
+    {name = "US Battle State 2", addr = 0x02226E1C},
+    {name = "US Wild Pokemon", addr = 0x0223AB00},
+    
+    -- EU version addresses
+    {name = "EU Battle State 1", addr = 0x02226E20},
+    {name = "EU Battle State 2", addr = 0x02226E24},
+    {name = "EU Wild Pokemon", addr = 0x0223AB08},
+    
+    -- Alternative addresses from other sources
+    {name = "Alt Battle Flag 1", addr = 0x02228870},
+    {name = "Alt Battle Flag 2", addr = 0x02228874},
+    {name = "Alt Battle Type", addr = 0x021BF6B0},
+    {name = "Alt Wild Data", addr = 0x0223AAF0},
+    
+    -- Battle-related flags
+    {name = "Battle Mode", addr = 0x02226E10},
+    {name = "Battle Status", addr = 0x02226E14},
+    {name = "Battle Turn", addr = 0x02226E28},
+    
+    -- Pokemon data areas
+    {name = "Enemy Pokemon 1", addr = 0x0223AB00},
+    {name = "Enemy Pokemon 2", addr = 0x0223AC00},
+    {name = "Wild Pokemon Alt", addr = 0x0223AD00},
+}
+
+-- Function to read different data sizes
+local function read_value(addr, size)
+    if size == 1 then
+        return memory.readbyte(addr)
+    elseif size == 2 then
+        return memory.readword(addr)
+    elseif size == 4 then
+        return memory.readdword(addr)
+    end
+    return 0
+end
+
+-- Main scanning function
+local scan_count = 0
+
+local function scan_memory()
+    scan_count = scan_count + 1
+    print("\n=== Scan #" .. scan_count .. " at " .. os.date("%H:%M:%S") .. " ===")
+    
+    local found_values = false
+    
+    for _, test in ipairs(addresses_to_test) do
+        local val_u8 = read_value(test.addr, 1)
+        local val_u16 = read_value(test.addr, 2)
+        
+        -- Only show non-zero values
+        if val_u8 > 0 or val_u16 > 0 then
+            print(string.format("%s (0x%08X): u8=%d, u16=%d", 
+                test.name, test.addr, val_u8, val_u16))
+            found_values = true
+        end
+    end
+    
+    if not found_values then
+        print("No non-zero values found. Make sure you're in a battle!")
+    end
+    
+    -- Also check for Pokemon species in the wild pokemon area
+    local wild_species = memory.readword(0x0223AB00)
+    local wild_level = memory.readbyte(0x0223AB00 + 0x54)
+    
+    if wild_species > 0 and wild_species < 1000 then
+        print(string.format("\nDetected Wild Pokemon: Species=%d, Level=%d", wild_species, wild_level))
+    end
+end
+
+-- Frame counter
+local frame_count = 0
+
+local function on_frame()
+    frame_count = frame_count + 1
+    
+    -- Scan every 60 frames (1 second)
+    if frame_count >= 60 then
+        frame_count = 0
+        scan_memory()
+    end
+end
+
+-- Initial scan
+scan_memory()
+
+-- Register frame callback
+gui.register(on_frame)

--- a/start_watcher.bat
+++ b/start_watcher.bat
@@ -32,7 +32,7 @@ if errorlevel 1 (
 echo ✅ Server is running
 echo.
 echo Starting event watcher...
-echo This will monitor C:/temp/soullink_events/ for JSON files from Lua script
+echo The watcher will auto-detect your OS and create the appropriate directory
 echo.
 
 REM Start the watcher


### PR DESCRIPTION
- Auto-detect Windows/Unix and use appropriate temp directories
- Create watch directory automatically on watcher startup
- Test write permissions before starting monitoring
- Update/create config.lua with correct output paths
- Add diagnostic Lua scripts for troubleshooting encounter detection
- Add pokemon_tracker_auto.lua with built-in OS detection
- Add helper scripts for testing memory addresses and battle detection
- Improve error messages with OS-specific instructions

This makes the setup process much more user-friendly by eliminating manual directory creation and path configuration issues.